### PR TITLE
Correctly operate on specfiles located below root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # See http://help.github.com/ignore-files/ for more about ignoring files.
 
+# editor
+*.swp
+
 # dependencies
 package-lock.json
 node_modules

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,7 +40,7 @@ async function run() {
     // setup rpm tree
     await exec.exec('rpmdev-setuptree');
 
-    // Copy spec file from path specFile to /root/rpmbuild/SPECS/
+    // Copy spec file from path specFile to /github/home/rpmbuild/SPECS/
     await exec.exec(`cp /github/workspace/${specFile} /github/home/rpmbuild/SPECS/`);
 
     // Make the code in /github/workspace/ into a tar.gz, located in /github/home/rpmbuild/SOURCES/

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ const exec = require('@actions/exec');
 const io = require('@actions/io');
 const cp = require('child_process');
 const fs = require('fs');
+const path = require('path');
 
 async function run() {
   try {
@@ -18,10 +19,15 @@ async function run() {
 
     // get inputs from workflow
     // specFile name
-    const specFile = core.getInput('spec_file');
+    const configPath = core.getInput('spec_file'); // user input, eg: `foo.spec' or `rpm/foo.spec'
+    const basename = path.basename(configPath); // always just `foo.spec`
+    const specFile = {
+      srcFullPath: `/github/workspace/${configPath}`,
+      destFullPath: `/github/home/rpmbuild/SPECS/${basename}`,
+    };
 
     // Read spec file and get values 
-    var data = fs.readFileSync(specFile, 'utf8');
+    var data = fs.readFileSync(specFile.srcFullPath, 'utf8');
     let name = '';       
     let version = '';
 
@@ -41,7 +47,7 @@ async function run() {
     await exec.exec('rpmdev-setuptree');
 
     // Copy spec file from path specFile to /github/home/rpmbuild/SPECS/
-    await exec.exec(`cp /github/workspace/${specFile} /github/home/rpmbuild/SPECS/`);
+    await exec.exec(`cp ${specFile.srcFullPath} ${specFile.destFullPath}`);
 
     // Make the code in /github/workspace/ into a tar.gz, located in /github/home/rpmbuild/SOURCES/
     const oldGitDir = process.env.GIT_DIR;
@@ -52,7 +58,7 @@ async function run() {
     // Execute rpmbuild , -ba generates both RPMS and SPRMS
     try {
       await exec.exec(
-        `rpmbuild -ba /github/home/rpmbuild/SPECS/${specFile}`
+        `rpmbuild -ba ${specFile.destFullPath}`
       );
     } catch (err) {
       core.setFailed(`action failed with error: ${err}`);


### PR DESCRIPTION
Hi @naveenrajm7,

These changes should resolve https://github.com/naveenrajm7/rpmbuild/issues/7.

Yesterday I was experimenting with using https://github.com/naveenrajm7/rpmbuild in order to package up a Node application as an RPM. I forked your repo because I needed to make a few fixes in order to get my experiment to work.

I noticed that @pboyd04 was also running into this same issue yesterday! I've cleaned up my messy fix a little bit.