### PR TITLE
Make rpmbuild work work with private repos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 
 # Installing tools needed for rpmbuild , 
 # depends on BuildRequires field in specfile, (TODO: take as input & install)
-RUN yum install -y rpm-build rpmdevtools gcc make coreutils python
+RUN yum install -y rpm-build rpmdevtools gcc make coreutils python git
 
 # Setting up node to run our JS file
 # Download Node Linux binary

--- a/lib/main.js
+++ b/lib/main.js
@@ -45,18 +45,11 @@ function run() {
             yield exec.exec('rpmdev-setuptree');
             // Copy spec file from path specFile to /root/rpmbuild/SPECS/
             yield exec.exec(`cp /github/workspace/${specFile} /github/home/rpmbuild/SPECS/`);
-            // Dowload tar.gz file of source code,  Reference : https://developer.github.com/v3/repos/contents/#get-archive-link
-            yield exec.exec(`curl -L --output tmp.tar.gz https://api.github.com/repos/${owner}/${repo}/tarball/${ref}`);
-            // create directory to match source file - %{name}-{version}.tar.gz of spec file
-            yield exec.exec(`mkdir ${name}-${version}`);
-            // Extract source code 
-            yield exec.exec(`tar xvf tmp.tar.gz -C ${name}-${version} --strip-components 1`);
-            // Create Source tar.gz file 
-            yield exec.exec(`tar -czvf ${name}-${version}.tar.gz ${name}-${version}`);
-            // // list files in current directory /github/workspace/
-            // await exec.exec('ls -la ');
-            // Copy tar.gz file to source path
-            yield exec.exec(`cp ${name}-${version}.tar.gz /github/home/rpmbuild/SOURCES/`);
+            // Make the code in /github/workspace/ into a tar.gz, located in /github/home/rpmbuild/SOURCES/
+            const oldGitDir = process.env.GIT_DIR;
+            process.env.GIT_DIR = '/github/workspace/.git';
+            yield exec.exec(`git archive --output=/github/home/rpmbuild/SOURCES/${name}-${version}.tar.gz --prefix=${name}-${version}/ HEAD`);
+            process.env.GIT_DIR = oldGitDir;
             // Execute rpmbuild , -ba generates both RPMS and SPRMS
             try {
                 yield exec.exec(`rpmbuild -ba /github/home/rpmbuild/SPECS/${specFile}`);


### PR DESCRIPTION
Resolves https://github.com/naveenrajm7/rpmbuild/issues/9

Previously, in order to create /github/home/rpmbuild/SOURCES/foo-1.2.0.tar.gz,
rpmbuild did the following:

1. use curl to download a tarball of the project source
2. unpack it into a local directory
3. repack it with the correct desired directory structure
4. move the repacked tarball to /github/home/rpmbuild/SOURCES

This failed for me at step 1 because the repo I'm trying to use rpmbuild on
is a private repo. There's no means of plumbing a github auth token into the
`curl` command, so the tarball fails to download and everything else fails.

----

Since we have the current repo tree in /github/workspace, we can coerce `git`
to make the archive for us. Now, we:

1. ask git to make the archive

and everything works with a private repo. In order to make this approach work,
I've added `git` into the build container.