### PR TITLE
Supports new user input: 'additional_repos'

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Create a workflow `.yml` file in your repositories `.github/workflows` directory
 ### Inputs
 
 - `spec_file`: The path to the spec file in your repo. [**required**]
+- `additional_repos`: A list of additional repositories (in JSON-array format) that you want enabled to build your rpm. [**optional**]
 
 ### Outputs
 
@@ -47,6 +48,7 @@ jobs:
       uses: naveenrajm7/rpmbuild@master
       with:
         spec_file: "cello.spec"
+		additional_repos: "['centos-release-scl', 'http://www.percona.com/downloads/percona-release/redhat/0.1-3/percona-release-0.1-3.noarch.rpm']"
 
     - name: Upload artifact
       uses: actions/upload-artifact@v1.0.0

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,9 @@ inputs:
     description: 'path to the spec file'
     required: true
     default: '*.spec'                     #Any spec file in top 
+  additional_repos:
+    description: 'A list of additional repositories to enable'
+    required: false
 
 outputs:
   source_rpm_path:

--- a/src/main.ts
+++ b/src/main.ts
@@ -67,7 +67,7 @@ async function run() {
 	}
 
 	// Installs build dependencies
-    await exec.exec(`yum-builddep ${specFile.destFullPath}`);
+    await exec.exec(`yum-builddep -y ${specFile.destFullPath}`);
 
     // Execute rpmbuild , -ba generates both RPMS and SPRMS
     try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,6 +56,16 @@ async function run() {
     await exec.exec(`ln -s /github/home/rpmbuild/SOURCES/${name}-${version}.tar.gz /github/home/rpmbuild/SOURCES/${name}.tar.gz`);
     process.env.GIT_DIR = oldGitDir;
 
+    // Installs additional repositories
+    const additionalRepos = core.getInput('additional_repos'); // user input, eg: '["centos-release-scl"]'
+	if (additionalRepos) {
+		const arr = JSON.parse(additionalRepos);
+		for (let i = 0; i < arr.length; i++) {
+			console.log(`Installing repo': ${arr[i]}`);
+    		await exec.exec(`yum install -y ${arr[i]}`);
+		};
+	}
+
 	// Installs build dependencies
     await exec.exec(`yum-builddep ${specFile.destFullPath}`);
 


### PR DESCRIPTION
Allows the user to specify additional repositories to enable before building the rpm

Signed-off-by: Cyrille Bollu <cyrille@debian-BULLSEYE-live-builder-AMD64>