### PR TITLE
pin nodejs/undici to v5.27.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "@actions/tool-cache": "^2.0.1",
     "@octokit/rest": "^17.1.4",
     "@types/node": "^12.0.4",
-    "typescript": "^3.5.1"
+    "typescript": "^3.5.1",
+    "undici": "5.27.2"
   },
   "devDependencies": {
     "@types/jest": "^24.0.13",


### PR DESCRIPTION
Since v5.28.0 [undici](https://github.com/nodejs/undici/) is not working with nodejs12. Check [here](https://github.com/nodejs/undici/issues/2469) for further information. Although there are a few [patches](https://github.com/nodejs/undici/pull/2470) available the problem is not fully addressed. Thus, lets pin undici to v5.27.2 to temporarily address the issue. Midterm solution should be an upgrade to a later nodejs version